### PR TITLE
일본어 문서에서 Noto Sans CJK 우선

### DIFF
--- a/pages/mediawiki:common.css
+++ b/pages/mediawiki:common.css
@@ -10,6 +10,17 @@
     NanumGothic, "맑은고딕", "Malgun Gothic", Dotum, sans-serif;
 }
 
+/*
+ * 일본어 문서 폰트는 Noto Sans CJK KR, 본고딕을 우선하기
+ */
+
+#mw-content-text:lang(ja) {
+  font-family: "Noto Sans CJK KR", "본고딕", "Noto Sans KR",
+    "Apple SD Gothic Neo", Arial,
+     "KoPubDotum Medium", "나눔바른고딕", "나눔고딕",
+    NanumGothic, "맑은고딕", "Malgun Gothic", Dotum, sans-serif;
+}
+
 /* 시각편집기에서 분류가 둘 나오는 것 가리기 */
 html.ve-active #catlinks {
   display: none;


### PR DESCRIPTION
일본어 문서의 가독성을 위해서 문서의 언어가 일본어로 지정된 경우, 사용하는 폰트로 Noto Sans CJK를 우선하도록 하였습니다.

Noto Sans CJK를 우선하도록 한 경우:
<img width="785" alt="image" src="https://user-images.githubusercontent.com/3305857/79871736-c27c4c80-841f-11ea-93ff-4c700c59ebb8.png">

한국어 문서와 같은 순서대로 폰트를 지정한 경우:
<img width="785" alt="image" src="https://user-images.githubusercontent.com/3305857/79871962-1f780280-8420-11ea-8d33-d4f7c9333933.png">

