### PR TITLE
Use position: fixed for anniversary icons

### DIFF
--- a/gadgets/image-in-search-bar/gadget:image-in-search-bar.css
+++ b/gadgets/image-in-search-bar/gadget:image-in-search-bar.css
@@ -4,7 +4,7 @@
 }
 #p-search #anniversary-icon {
   display: block;
-  position: absolute;
+  position: fixed;
   right: 0.3rem;
   bottom: 0.3rem;
   height: 1.8rem;


### PR DESCRIPTION
스크롤하면 에모지들이 내용과 같이 올라가 버리는 문제를 해결합니다.