### PR TITLE
편집을 유도하도록 디자인 개선

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -54,7 +54,7 @@ jobs:
       run: pytest
 
     - name: Apply
-      if: success()
+      if: github.ref == 'refs/heads/main' && success()
       env:
         FEMIWIKI_BOT_PASSWORD: ${{ secrets.FEMIWIKI_BOT_PASSWORD }}
       run: |

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -54,7 +54,7 @@ jobs:
       run: pytest
 
     - name: Apply
-      if: github.ref == 'refs/heads/main' && success()
+      if: success()
       env:
         FEMIWIKI_BOT_PASSWORD: ${{ secrets.FEMIWIKI_BOT_PASSWORD }}
       run: |

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -1,34 +1,58 @@
-#ca-ve-edit,
-#ca-view + #ca-edit {
-  position: fixed;
-  bottom: 2rem;
-  right: 5rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-  border-radius: 50%;
-  height: 3rem;
-  width: 3rem;
-  z-index: 100;
-  animation: help-panel-slidein 800ms;
-  background-color: #bad75b;
-}
-
-#ca-ve-edit a,
-#ca-view + #ca-edit a {
-  width: 3rem;
-  height: 3rem;
-  display: block;
-  border-radius: 50%;
+/* 초설의 안 */
+#ca-ve-edit {
+  background-color: #c3bffd;
+  font-size: 1rem;
+  padding: 0.5em 1em;
+  border: 1px solid #a0a0ff;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-block;
   text-align: center;
-  line-height: 3rem;
-  color: white;
-  background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
-  background-repeat: no-repeat;
-  background-size: 1.5rem;
-  background-position: 0.725rem;
-  filter: invert(1);
+  transition:
+    background-color 0.3s,
+    transform 0.2s;
+}
+#ca-ve-edit:hover {
+  background-color: #a0a0ff;
+  transform: scale(1.05);
 }
 
-#ca-ve-edit span,
-#ca-view + #ca-edit a {
-  font-size: 0;
+#ca-ve-edit a {
+  color: #ffffff;
 }
+
+/* 낙엽의 안 */
+/* #ca-ve-edit, */
+/* #ca-view + #ca-edit { */
+/* position: fixed; */
+/* bottom: 2rem; */
+/* right: 5rem; */
+/* box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5); */
+/* border-radius: 50%; */
+/* height: 3rem; */
+/* width: 3rem; */
+/* z-index: 100; */
+/* animation: help-panel-slidein 800ms; */
+/* background-color: #bad75b; */
+/* } */
+
+/* #ca-ve-edit a, */
+/* #ca-view + #ca-edit a { */
+/* width: 3rem; */
+/* height: 3rem; */
+/* display: block; */
+/* border-radius: 50%; */
+/* text-align: center; */
+/* line-height: 3rem; */
+/* color: white; */
+/* background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg); */
+/* background-repeat: no-repeat; */
+/* background-size: 1.5rem; */
+/* background-position: 0.725rem; */
+/* filter: invert(1); */
+/* } */
+
+/* #ca-ve-edit span, */
+/* #ca-view + #ca-edit a { */
+/* font-size: 0; */
+/* } */

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -8,7 +8,7 @@
   height: 3rem;
   width: 3rem;
   z-index: 100;
-  animation: help-panel-slidein 1000ms;
+  animation: help-panel-slidein 800ms;
   background-color: #bad75b;
 }
 

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -4,12 +4,9 @@
   padding-bottom: 2em;
 }
 
-#p-header #lastmod-and-views #p-views {
-  vertical-align: baseline;
-}
-
 #p-header #lastmod-and-views #p-views ul li {
   display: inline-block;
+  vertical-align: baseline;
   float: none;
 }
 
@@ -35,11 +32,24 @@
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit a {
   color: #ffffff;
+  vertical-align: middle;
 }
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit a:hover {
   color: #ffffff;
   border: none;
+}
+
+#p-header #lastmod-and-views #p-views #ca-ve-edit a:before {
+  content: '';
+  display: inline-block;
+  background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
+  filter: invert(1);
+  padding-right: 0.3em;
+  background-repeat: no-repeat;
+  vertical-align: middle;
+  height: 1em;
+  width: 1em;
 }
 
 /* 낙엽의 안 */

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -1,10 +1,24 @@
 /* 초설의 안 */
-#ca-ve-edit {
+#p-header #lastmod-and-views {
+  overflow: visible;
+  padding-bottom: 2em;
+}
+
+#p-header #lastmod-and-views #p-views {
+  vertical-align: baseline;
+}
+
+#p-header #lastmod-and-views #p-views ul li {
+  display: inline-block;
+  float: none;
+}
+
+#p-header #lastmod-and-views #p-views #ca-ve-edit {
   background-color: #c3bffd;
   font-size: 1rem;
   padding: 0.5em 1em;
   border: 1px solid #a0a0ff;
-  border-radius: 5px;
+  border-radius: 0.3em;
   cursor: pointer;
   display: inline-block;
   text-align: center;
@@ -12,12 +26,18 @@
     background-color 0.3s,
     transform 0.2s;
 }
-#ca-ve-edit:hover {
+
+#p-header #lastmod-and-views #p-views #ca-ve-edit:hover {
+  border-color: #6b6bff;
   background-color: #a0a0ff;
   transform: scale(1.05);
 }
 
-#ca-ve-edit a {
+#p-header #lastmod-and-views #p-views #ca-ve-edit a {
+  color: #ffffff;
+}
+
+#p-header #lastmod-and-views #p-views #ca-ve-edit a:hover {
   color: #ffffff;
 }
 

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -1,24 +1,20 @@
 /* 초설의 안 */
 #p-header #lastmod-and-views {
-  overflow: visible;
-  padding-bottom: 2em;
+  padding: 0.1em 0;
 }
 
 #p-header #lastmod-and-views #p-views ul li {
   display: inline-block;
-  vertical-align: baseline;
   float: none;
 }
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit {
   background-color: #c3bffd;
   font-size: 1rem;
-  padding: 0.5em 1em;
+  padding: 0.3em 0.5em;
   border: 1px solid #a0a0ff;
   border-radius: 0.3em;
   cursor: pointer;
-  display: inline-block;
-  text-align: center;
   transition:
     background-color 0.3s,
     transform 0.2s;
@@ -32,7 +28,8 @@
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit a {
   color: #ffffff;
-  vertical-align: middle;
+  display: flex;
+  align-items: center;
 }
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit a:hover {
@@ -40,9 +37,12 @@
   border: none;
 }
 
+#p-header #lastmod-and-views #p-views #ca-ve-edit a:focus {
+  border: none;
+}
+
 #p-header #lastmod-and-views #p-views #ca-ve-edit a:before {
   content: '';
-  display: inline-block;
   background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
   filter: invert(1);
   padding-right: 0.3em;

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -1,0 +1,34 @@
+#ca-ve-edit,
+#ca-view + #ca-edit {
+  position: fixed;
+  bottom: 2rem;
+  right: 5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  border-radius: 50%;
+  height: 3rem;
+  width: 3rem;
+  z-index: 100;
+  animation: help-panel-slidein 1000ms;
+  background-color: #bad75b;
+}
+
+#ca-ve-edit a,
+#ca-view + #ca-edit a {
+  width: 3rem;
+  height: 3rem;
+  display: block;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 3rem;
+  color: white;
+  background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
+  background-repeat: no-repeat;
+  background-size: 1.5rem;
+  background-position: 0.725rem;
+  filter: invert(1);
+}
+
+#ca-ve-edit span,
+#ca-view + #ca-edit a {
+  font-size: 0;
+}

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -8,7 +8,8 @@
   float: none;
 }
 
-#p-header #lastmod-and-views #p-views #ca-ve-edit {
+#p-header #lastmod-and-views #p-views #ca-ve-edit,
+#p-header #lastmod-and-views #p-views #ca-edit {
   background-color: #c3bffd;
   font-size: 1rem;
   padding: 0.3em 0.5em;
@@ -22,27 +23,33 @@
 }
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit:hover,
-#p-header #lastmod-and-views #p-views #ca-ve-edit:focus {
+#p-header #lastmod-and-views #p-views #ca-ve-edit:focus,
+#p-header #lastmod-and-views #p-views #ca-edit:hover,
+#p-header #lastmod-and-views #p-views #ca-edit:focus {
   border-color: #6b6bff;
   background-color: #a0a0ff;
   transform: scale(1.05);
 }
 
+#p-header #lastmod-and-views #p-views #ca-edit a,
 #p-header #lastmod-and-views #p-views #ca-ve-edit a {
   color: #ffffff;
   display: flex;
   align-items: center;
 }
 
-#p-header #lastmod-and-views #p-views #ca-ve-edit a:hover {
+#p-header #lastmod-and-views #p-views #ca-ve-edit a:hover,
+#p-header #lastmod-and-views #p-views #ca-edit a:hover {
   color: #ffffff;
   border: none;
 }
 
-#p-header #lastmod-and-views #p-views #ca-ve-edit a:focus {
+#p-header #lastmod-and-views #p-views #ca-ve-edit a:focus,
+#p-header #lastmod-and-views #p-views #ca-edit a:focus {
   border: none;
 }
 
+#p-header #lastmod-and-views #p-views #ca-edit a:before,
 #p-header #lastmod-and-views #p-views #ca-ve-edit a:before {
   content: '';
   background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
@@ -54,39 +61,3 @@
   height: 1em;
   width: 1em;
 }
-
-/* 낙엽의 안 */
-/* #ca-ve-edit, */
-/* #ca-view + #ca-edit { */
-/* position: fixed; */
-/* bottom: 2rem; */
-/* right: 5rem; */
-/* box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5); */
-/* border-radius: 50%; */
-/* height: 3rem; */
-/* width: 3rem; */
-/* z-index: 100; */
-/* animation: help-panel-slidein 800ms; */
-/* background-color: #bad75b; */
-/* } */
-
-/* #ca-ve-edit a, */
-/* #ca-view + #ca-edit a { */
-/* width: 3rem; */
-/* height: 3rem; */
-/* display: block; */
-/* border-radius: 50%; */
-/* text-align: center; */
-/* line-height: 3rem; */
-/* color: white; */
-/* background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg); */
-/* background-repeat: no-repeat; */
-/* background-size: 1.5rem; */
-/* background-position: 0.725rem; */
-/* filter: invert(1); */
-/* } */
-
-/* #ca-ve-edit span, */
-/* #ca-view + #ca-edit a { */
-/* font-size: 0; */
-/* } */

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -39,6 +39,7 @@
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit a:hover {
   color: #ffffff;
+  border: none;
 }
 
 /* 낙엽의 안 */

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -1,6 +1,6 @@
 /* 초설의 안 */
 #p-header #lastmod-and-views {
-  padding: 0.1em 0;
+  padding: 0.3em 0;
 }
 
 #p-header #lastmod-and-views #p-views ul li {
@@ -15,12 +15,14 @@
   border: 1px solid #a0a0ff;
   border-radius: 0.3em;
   cursor: pointer;
+  box-shadow:  0 1px 2px rgba(0, 0, 0, 0.5);
   transition:
     background-color 0.3s,
     transform 0.2s;
 }
 
-#p-header #lastmod-and-views #p-views #ca-ve-edit:hover {
+#p-header #lastmod-and-views #p-views #ca-ve-edit:hover,
+#p-header #lastmod-and-views #p-views #ca-ve-edit:focus {
   border-color: #6b6bff;
   background-color: #a0a0ff;
   transform: scale(1.05);
@@ -44,6 +46,7 @@
 #p-header #lastmod-and-views #p-views #ca-ve-edit a:before {
   content: '';
   background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
+  background-size: 1em;
   filter: invert(1);
   padding-right: 0.3em;
   background-repeat: no-repeat;

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -17,9 +17,7 @@
   border-radius: 0.3em;
   cursor: pointer;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-  transition:
-    background-color 0.3s,
-    transform 0.2s;
+  transition: background-color 0.3s;
 }
 
 #p-header #lastmod-and-views #p-views #ca-ve-edit:hover,
@@ -28,7 +26,6 @@
 #p-header #lastmod-and-views #p-views #ca-edit:focus {
   border-color: #6b6bff;
   background-color: #a0a0ff;
-  transform: scale(1.05);
 }
 
 #p-header #lastmod-and-views #p-views #ca-edit a,

--- a/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
+++ b/gadgets/big-edit-button/mediawiki%3Agadget-big-edit-button.css
@@ -15,7 +15,7 @@
   border: 1px solid #a0a0ff;
   border-radius: 0.3em;
   cursor: pointer;
-  box-shadow:  0 1px 2px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   transition:
     background-color 0.3s,
     transform 0.2s;

--- a/gadgets/big-edit-button/mediawiki%3Agadgets%2Fbig-edit-button.json
+++ b/gadgets/big-edit-button/mediawiki%3Agadgets%2Fbig-edit-button.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "rights": ["editprotected"],
+    "rights": [],
     "default": true,
     "hidden": true,
     "skins": ["femiwiki"],

--- a/gadgets/big-edit-button/mediawiki%3Agadgets%2Fbig-edit-button.json
+++ b/gadgets/big-edit-button/mediawiki%3Agadgets%2Fbig-edit-button.json
@@ -11,6 +11,6 @@
     "peers": [],
     "dependencies": [],
     "messages": [],
-    "type": "general"
+    "type": "styles"
   }
 }

--- a/gadgets/big-edit-button/mediawiki%3Agadgets%2Fbig-edit-button.json
+++ b/gadgets/big-edit-button/mediawiki%3Agadgets%2Fbig-edit-button.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "rights": ["editprotected"],
+    "default": true,
+    "hidden": true,
+    "skins": ["femiwiki"],
+    "category": "view"
+  },
+  "module": {
+    "pages": ["big-edit-button.css"],
+    "peers": [],
+    "dependencies": [],
+    "messages": [],
+    "type": "general"
+  }
+}

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.css
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.css
@@ -1,7 +1,7 @@
 .fw-edit {
   position: fixed;
   bottom: 2rem;
-  right: 5rem;
+  right: 1rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   border-radius: 50%;
   height: 3rem;

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.css
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.css
@@ -1,0 +1,29 @@
+.fw-edit {
+  position: fixed;
+  bottom: 2rem;
+  right: 5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  border-radius: 50%;
+  height: 3rem;
+  width: 3rem;
+  z-index: 100;
+  animation: help-panel-slidein 800ms;
+  background-color: #bad75b;
+  cursor: pointer;
+}
+
+.fw-edit:after {
+  content: '';
+  width: 3rem;
+  height: 3rem;
+  display: block;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 3rem;
+  color: white;
+  background-image: url(https://upload.wikimedia.org/wikipedia/commons/8/8a/OOjs_UI_icon_edit-ltr.svg);
+  background-repeat: no-repeat;
+  background-size: 1.5rem;
+  background-position: 0.725rem;
+  filter: invert(1);
+}

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
@@ -1,8 +1,14 @@
 // <nowiki>
 'use strict';
 (() => {
-  // 편집 불가한 경우에만 표시
-  if (document.body.classList.contains('mw-editable')) {
+  if (
+    // 편집 불가한 경우에만 표시
+    document.body.classList.contains('mw-editable') ||
+    // 주제 이름공간에서만 표시(특수 문서 등은 제외)
+    !document.body.classList.contains('ns-subject') ||
+    // 보기에서만 표시 (역사 등은 제외)
+    !document.body.classList.contains('action-view')
+  ) {
     return;
   }
 

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
@@ -23,12 +23,12 @@
           {
             action: 'accept',
             label: OO.ui.deferMsg('userlogin-joinproject'),
-            flags: 'primary',
+            flags: ['primary', 'progressive'],
           },
           {
             action: 'reject',
             label: OO.ui.deferMsg('ooui-dialog-message-reject'),
-            flags: ['safe', 'progressive'],
+            flags: 'safe',
           },
         ],
       })

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
@@ -22,7 +22,7 @@
           {
             action: 'reject',
             label: OO.ui.deferMsg('ooui-dialog-message-reject'),
-            flags: 'safe', 'progressive',
+            flags: ['safe', 'progressive'],
           },
         ],
       })

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
@@ -12,7 +12,7 @@
   element.title = mw.msg('tooltip-ca-edit');
   element.addEventListener('click', (e) => {
     OO.ui
-      .confirm('가입하면 내용을 직접 고칠 수 있습니다.', {
+      .confirm('내용을 직접 고칠 수 있습니다.', {
         actions: [
           {
             action: 'accept',
@@ -22,7 +22,7 @@
           {
             action: 'reject',
             label: OO.ui.deferMsg('ooui-dialog-message-reject'),
-            flags: 'safe',
+            flags: 'safe', 'progressive',
           },
         ],
       })

--- a/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
+++ b/gadgets/recommend-edit/mediawiki%3Agadget-recommend-edit.js
@@ -1,0 +1,41 @@
+// <nowiki>
+'use strict';
+(() => {
+  // 편집 불가한 경우에만 표시
+  if (document.body.classList.contains('mw-editable')) {
+    return;
+  }
+
+  const element = document.createElement('div');
+  element.classList.add('fw-edit');
+  element.innerHtml = mw.msg('skin-view-edit');
+  element.title = mw.msg('tooltip-ca-edit');
+  element.addEventListener('click', (e) => {
+    OO.ui
+      .confirm('가입하면 내용을 직접 고칠 수 있습니다.', {
+        actions: [
+          {
+            action: 'accept',
+            label: OO.ui.deferMsg('userlogin-joinproject'),
+            flags: 'primary',
+          },
+          {
+            action: 'reject',
+            label: OO.ui.deferMsg('ooui-dialog-message-reject'),
+            flags: 'safe',
+          },
+        ],
+      })
+      .done((confirmed) => {
+        if (confirmed) {
+          window.location.href = new mw.Title('Special:CreateAccount').getUrl({
+            returnto: mw.config.get('wgPageName'),
+          });
+        }
+      });
+  });
+
+  const content = document.querySelector('#content');
+  content.append(element);
+})();
+// </nowiki>

--- a/gadgets/recommend-edit/mediawiki%3Agadgets%2Frecommend-edit.json
+++ b/gadgets/recommend-edit/mediawiki%3Agadgets%2Frecommend-edit.json
@@ -1,0 +1,23 @@
+{
+  "settings": {
+    "rights": [],
+    "default": true,
+    "hidden": true,
+    "skins": ["femiwiki"],
+    "category": "view"
+  },
+  "module": {
+    "pages": ["recommend-edit.js", "recommend-edit.css"],
+    "peers": [],
+    "dependencies": [
+      "oojs-ui-windows",
+      "ext.growthExperiments.HelpPanelCta.styles"
+    ],
+    "messages": [
+      "skin-view-edit",
+      "userlogin-joinproject",
+      "ooui-dialog-message-reject"
+    ],
+    "type": "general"
+  }
+}


### PR DESCRIPTION
https://github.com/femiwiki/femiwiki/issues/300

비 로그인 사용자의 경우 회원가입을 유도합니다.
1. 회원가입으로 안내하는 버튼은 눈에 무조건 띄도록 헬프 패널[^1] 버튼을 똑같이 참고 했습니다.
2. 바로 회원가입으로 이동하면 당황스러울 거라 생각해 짧은 안내 confirm을 넣었습니다. 문구 "내용을 직접 고칠 수 있습니다."는 좀 더 구어체를 쓰고 싶었는데 머리가 안 돌아 저렇게 뒀습니다.

회원가입 직후 원래 보던 문서로 돌아올 뿐 편집이 시작되지는 않으므로
로그인 사용자는 편집 버튼이 돋보이는 형태로 나오게 합니다.

- https://github.com/femiwiki/FemiwikiSkin/pull/782 에서 초설님이 만드신 편집 버튼에서 조금 변형했습니다. 

버튼들 디자인 컨셉은,
- 개인적으로 저희 위키가 공책처럼 생겼다 생각하는데
종이 위에 올려놓은 물건들 느낌으로 생각했습니다.
- 색깔은 초록색은 중요한 안내에 쓰고 있었는데 비로그인 시에는 초록색 볼일이 거의 없으므로 편하게 썼고
로그인 시에는 더 중요한 알림이 많으니 보라색으로 뒀습니다.

[^1]: https://mediawiki.org/wiki/Help:Growth/Tools/Help_panel