### PR TITLE
안드로이드와 아이폰을 다시 시각편집기가 지원되지 않는 환경으로 표기

### DIFF
--- a/gadgets/visual-editor-for-femiwiki/mediawiki%3Agadget-visual-editor-for-femiwiki.js
+++ b/gadgets/visual-editor-for-femiwiki/mediawiki%3Agadget-visual-editor-for-femiwiki.js
@@ -218,23 +218,5 @@
   mw.loader.using(['ext.visualEditor.core']).done(function () {
     addDashSequence(); // for Stuructured Discussion
   });
-
-  /**
-   * 아이폰과 안드로이드에서 [[미디어위키:Visualeditor-browserwarning]] 경고가
-   * 뜨지 않게 합니다.
-   * https://github.com/femiwiki/mediawiki/issues/262
-   */
-  mw.libs.ve.addPlugin(function () {
-    try {
-      ve.init.mw.DesktopArticleTarget.static.compatibility.supportedList[
-        'iphone'
-      ] = null;
-      ve.init.mw.DesktopArticleTarget.static.compatibility.supportedList[
-        'android'
-      ] = null;
-    } catch (e) {
-      console.log('Error', e.stack);
-    }
-  });
 })(mediaWiki, jQuery);
 // </nowiki>


### PR DESCRIPTION
당시 모바일 프론트엔드 설치 전이라 이게 아니면 시각편집기를 못써서 경고를 지웠으나
이제 대체제가 있으니.경고문구 재출력