### PR TITLE
chore: create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "remote-gadgets"
+version = "0.0.0"
+dependencies = [
+  "mwclient==0.10.1",
+]
+
+[dependency-groups]
+dev = [
+  "flake8==7.2.0",
+  "pytest==8.3.5",
+]


### PR DESCRIPTION
주로 uv 사용자를 위해... (`uv sync`)

pip만 쓰면 파일 트리 재구성 없이 pyproject.toml만 쓸 수 있는 방법은 없어서 (https://github.com/pypa/pip/issues/11440) 기존 requirements.txt를 지우지는 않았습니다.